### PR TITLE
Add warning about cert expiration

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -169,6 +169,8 @@ For security reasons, encryption is required for communication with the OpenSear
 
 Depending on your requirements, the Operator offers two ways of managing TLS certificates. You can either supply your own certificates, or the Operator will generate its own CA and sign certificates for all nodes using that CA. The second option is recommended, unless you want to directly expose your OpenSearch cluster outside your Kubernetes cluster, or your organization has rules about using self-signed certificates for internal communication.
 
+> :warning: **Clusters with operator-generated certificates will stop working after 1 year**: Make sure you are test certificate renewals in your cluster before putting it in production!
+
 TLS certificates are used in three places, and each can be configured independently.
 
 #### Node Transport


### PR DESCRIPTION
This PR adds a warning to make users aware of the 1-year validity time of operator-generated certificates. When documentation for renewing the certificates is available, it would be good to add link to it from here.